### PR TITLE
Fixed `invalid escape sequence` warning in Python 3.12 or later

### DIFF
--- a/pyshbench
+++ b/pyshbench
@@ -35,7 +35,7 @@ if (len(sys.argv) != 4 or int(sys.argv[3]) < 2):
 
 base, test, diff = [], [], []
 runs = int(sys.argv[3])
-exp = re.compile(b"Nodes/second\s*: (\d+)")
+exp = re.compile(br"Nodes/second\s*: (\d+)")
 
 # determine CPU sets to run on
 # this assumes that logical cpus on the same core are numbered sequentially
@@ -80,7 +80,7 @@ print("P(speedup > 0) = {:>7.4f}".format(CDF(diff_mean / diff_sdev)))
 
 cpu = str()
 if os.path.exists("/proc/cpuinfo"):
-	exp = re.compile ("^model name\s+:\s+(.*)$")
+	exp = re.compile (r"^model name\s+:\s+(.*)$")
 	with open('/proc/cpuinfo','r') as infile:
 		for line in infile:
 			m = exp.match(line)


### PR DESCRIPTION
In string literals marked with r"...", Python will understand that `\s` is part of the regular expression pattern and not an escape character.

The error was the following:
On Windows:
```
C:\r\pyshbench\pyshbench:38: SyntaxWarning: invalid escape sequence '\s'
  exp = re.compile(b"Nodes/second\s*: (\d+)")
C:\r\pyshbench\pyshbench:83: SyntaxWarning: invalid escape sequence '\s'                                           
  exp = re.compile ("^model name\s+:\s+(.*)$")           
```

On Linux: 
```
/home/maxim/git/pyshbench/pyshbench:38: SyntaxWarning: invalid escape sequence '\s'
  exp = re.compile(b"Nodes/second\s*: (\d+)")
/home/maxim/git/pyshbench/pyshbench:83: SyntaxWarning: invalid escape sequence '\s'
  exp = re.compile ("^model name\s+:\s+(.*)$")
```